### PR TITLE
Update runtime to 25.08

### DIFF
--- a/io.blockloader.BlockLoader.desktop
+++ b/io.blockloader.BlockLoader.desktop
@@ -4,3 +4,5 @@ Name=BlockLoader
 Exec=blockloader
 Icon=io.blockloader.BlockLoader
 Type=Application
+Categories=Game;
+Keywords=Mod;Manager;Minecraft;

--- a/io.blockloader.BlockLoader.metainfo.xml
+++ b/io.blockloader.BlockLoader.metainfo.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2023 BlockLoader LLC -->
-
-<component type="desktop">
+<component type="desktop-application">
     <id>io.blockloader.BlockLoader</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>LicenseRef-proprietary</project_license>
     <name>BlockLoader</name>
+    <summary>The best Minecraft mod manager</summary>
     <url type="homepage">https://blockloader.io</url>
-    <developer_name>BlockLoader LLC</developer_name>
+    <developer id="io.blockloader"><name>BlockLoader LLC</name></developer>
     <icon type="remote" height="500" width="500">https://cdn.blockloader.io/logo.png</icon>
     <launchable type="desktop-id">io.blockloader.BlockLoader.desktop</launchable>
-    <summary>The best Minecraft mod manager</summary>
+    <content_rating type="oars-1.1"/>
     <description>
         <p>BlockLoader is a mod manager for Minecraft that aims to make installing and managing your
             mods as simple as possible.</p>
@@ -36,5 +36,4 @@
         <release version="0.5.7" date="2023-03-20" />
         <release version="0.5.6" date="2023-02-26" />
     </releases>
-    <content_rating type="oars-1.1"/>
 </component>

--- a/io.blockloader.BlockLoader.yml
+++ b/io.blockloader.BlockLoader.yml
@@ -1,12 +1,13 @@
 app-id: io.blockloader.BlockLoader
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '25.08'
 command: blockloader
 separate-locales: false
 finish-args:
+  - --device=dri
   - --share=ipc
   - --socket=x11
   - --socket=pulseaudio


### PR DESCRIPTION
Update runtime from 22.08 to 25.08.

Fixes: https://github.com/flathub/io.blockloader.BlockLoader/issues/8

<img width="1000" height="720" alt="image" src="https://github.com/user-attachments/assets/aaa4dda5-753f-4e82-b30f-4fc40ac44fe8" />
